### PR TITLE
fix emit

### DIFF
--- a/src/instance/methods.js
+++ b/src/instance/methods.js
@@ -137,8 +137,10 @@ Moon.prototype.emit = function(eventName, customMeta) {
   var globalHandlers = this.$events["*"];
 
   // Call all handlers for the event name
-  for(var i = 0; i < handlers.length; i++) {
-    handlers[i](meta);
+  if(handlers !== undefined) {
+    for(var i = 0; i < handlers.length; i++) {
+      handlers[i](meta);
+    }
   }
 
   if(globalHandlers !== undefined) {


### PR DESCRIPTION
When emiting an event without having any listener it fails. Added a check to avoid going through the handler array if it doesn't exist.